### PR TITLE
Updated all Object references to Objekt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,14 @@
     "autoload-dev": {
         "psr-4": { "Memio\\Memio\\Examples\\": "examples" }
     },
+    "repositories": [
+        {"type": "vcs", "url": "https://github.com/webhdx/twig-template-engine.git"}
+    ],
     "require": {
         "memio/linter": "^2.0@alpha",
         "memio/model": "^2.0@alpha",
         "memio/pretty-printer": "^2.0@alpha",
-        "memio/twig-template-engine": "^2.0@alpha",
+        "memio/twig-template-engine": "dev-twig3 as 2.0.x-dev",
         "memio/validator": "^2.0@alpha",
         "php": "^7.0"
     },

--- a/config/Build.php
+++ b/config/Build.php
@@ -61,8 +61,8 @@ class Build
      */
     public static function prettyPrinter()
     {
-        $loader = new \Twig_Loader_Filesystem(\Memio\TwigTemplateEngine\Config\Locate::templates());
-        $twig = new \Twig_Environment($loader);
+        $loader = new \Twig\Loader\FilesystemLoader(\Memio\TwigTemplateEngine\Config\Locate::templates());
+        $twig = new \Twig\Environment($loader);
 
         $line = new \Memio\TwigTemplateEngine\TwigExtension\Line\Line();
         $line->add(new \Memio\TwigTemplateEngine\TwigExtension\Line\ContractLineStrategy());

--- a/examples/FileTest.php
+++ b/examples/FileTest.php
@@ -16,7 +16,7 @@ use Memio\Model\Constant;
 use Memio\Model\File;
 use Memio\Model\FullyQualifiedName;
 use Memio\Model\Method;
-use Memio\Model\Object;
+use Memio\Model\Objekt;
 use Memio\Model\Phpdoc\LicensePhpdoc;
 use Memio\Model\Property;
 
@@ -32,7 +32,7 @@ class FileTest extends PrettyPrinterTestCase
     public function testEmpty()
     {
         $file = (new File(self::FILENAME))
-            ->setStructure(new Object(self::FULLY_QUALIFIED_NAME))
+            ->setStructure(new Objekt(self::FULLY_QUALIFIED_NAME))
         ;
 
         $generatedCode = $this->prettyPrinter->generateCode($file);
@@ -45,7 +45,7 @@ class FileTest extends PrettyPrinterTestCase
         $file = (new File(self::FILENAME))
             ->setLicensePhpdoc(new LicensePhpdoc(self::PROJECT_NAME, self::AUTHOR_NAME, self::AUTHOR_EMAIL))
 
-            ->setStructure(new Object(self::FULLY_QUALIFIED_NAME))
+            ->setStructure(new Objekt(self::FULLY_QUALIFIED_NAME))
         ;
 
         $generatedCode = $this->prettyPrinter->generateCode($file);
@@ -58,7 +58,7 @@ class FileTest extends PrettyPrinterTestCase
         $file = (new File(self::FILENAME))
             ->addFullyQualifiedName(new FullyQualifiedName('DateTime'))
 
-            ->setStructure((new Object(self::FULLY_QUALIFIED_NAME))
+            ->setStructure((new Objekt(self::FULLY_QUALIFIED_NAME))
                 ->addConstant(new Constant('FIRST_CONSTANT', '0'))
                 ->addConstant(new Constant('SECOND_CONSTANT', "'meh'"))
 

--- a/examples/ObjectTest.php
+++ b/examples/ObjectTest.php
@@ -15,7 +15,7 @@ use Memio\Model\Argument;
 use Memio\Model\Constant;
 use Memio\Model\Contract;
 use Memio\Model\Method;
-use Memio\Model\Object;
+use Memio\Model\Objekt;
 use Memio\Model\Phpdoc\ApiTag;
 use Memio\Model\Phpdoc\Description;
 use Memio\Model\Phpdoc\DeprecationTag;
@@ -28,7 +28,7 @@ class ObjectTest extends PrettyPrinterTestCase
 
     public function testEmpty()
     {
-        $object = new Object(self::NAME);
+        $object = new Objekt(self::NAME);
 
         $generatedCode = $this->prettyPrinter->generateCode($object);
 
@@ -37,7 +37,7 @@ class ObjectTest extends PrettyPrinterTestCase
 
     public function testWithPhpdoc()
     {
-        $object = (new Object(self::NAME))
+        $object = (new Objekt(self::NAME))
             ->setPhpdoc((new StructurePhpdoc())
                 ->setDescription((new Description('Short description'))
                     ->addEmptyLine()
@@ -55,7 +55,7 @@ class ObjectTest extends PrettyPrinterTestCase
 
     public function testFinal()
     {
-        $object = (new Object(self::NAME))
+        $object = (new Objekt(self::NAME))
             ->makeFinal()
         ;
 
@@ -66,8 +66,8 @@ class ObjectTest extends PrettyPrinterTestCase
 
     public function testFull()
     {
-        $object = (new Object(self::NAME))
-            ->extend(new Object('MyParent'))
+        $object = (new Objekt(self::NAME))
+            ->extend(new Objekt('MyParent'))
 
             ->implement(new Contract('FirstContract'))
             ->implement(new Contract('SecondContract'))


### PR DESCRIPTION
Looks like this package is pretty much abandoned but I will try. 

I've created another PR adding compatibility to Twig 3: https://github.com/memio/twig-template-engine/pull/9

There was an issue with newer PHP versions (7.3 in my case) in which `Object` word is prohibited. I've noticed you already changed `Object` class to `Objekt` but there were still a lot of references left. This PR fixes all of those making your package compatible with PHP 7.3.

Can you review it and merge+release as soon as possible? We rely on your package in https://github.com/ezsystems/ezplatform-http-cache

## TODO
- [ ] Remove `[TMP]` commit before merging